### PR TITLE
DBAL 4 compatibility fixes: Doctrine\*::getSQLDeclaration

### DIFF
--- a/src/Doctrine/Geometry.php
+++ b/src/Doctrine/Geometry.php
@@ -9,12 +9,12 @@ class Geometry extends Type
 {
     const GEOMETRY = 'geometry';
 
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
         return 'geometry';
     }
 
-    public function getName()
+    public function getName(): string
     {
         return self::GEOMETRY;
     }

--- a/src/Doctrine/GeometryCollection.php
+++ b/src/Doctrine/GeometryCollection.php
@@ -9,12 +9,12 @@ class GeometryCollection extends Type
 {
     const GEOMETRYCOLLECTION = 'geometrycollection';
 
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
         return 'geometrycollection';
     }
 
-    public function getName()
+    public function getName(): string
     {
         return self::GEOMETRYCOLLECTION;
     }

--- a/src/Doctrine/LineString.php
+++ b/src/Doctrine/LineString.php
@@ -9,12 +9,12 @@ class LineString extends Type
 {
     const LINESTRING = 'linestring';
 
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
         return 'linestring';
     }
 
-    public function getName()
+    public function getName(): string
     {
         return self::LINESTRING;
     }

--- a/src/Doctrine/MultiLineString.php
+++ b/src/Doctrine/MultiLineString.php
@@ -9,12 +9,12 @@ class MultiLineString extends Type
 {
     const MULTILINESTRING = 'multilinestring';
 
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
         return 'multilinestring';
     }
 
-    public function getName()
+    public function getName(): string
     {
         return self::MULTILINESTRING;
     }

--- a/src/Doctrine/MultiPoint.php
+++ b/src/Doctrine/MultiPoint.php
@@ -9,12 +9,12 @@ class MultiPoint extends Type
 {
     const MULTIPOINT = 'multipoint';
 
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
         return 'multipoint';
     }
 
-    public function getName()
+    public function getName(): string
     {
         return self::MULTIPOINT;
     }

--- a/src/Doctrine/MultiPolygon.php
+++ b/src/Doctrine/MultiPolygon.php
@@ -9,12 +9,12 @@ class MultiPolygon extends Type
 {
     const MULTIPOLYGON = 'multipolygon';
 
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
         return 'multipolygon';
     }
 
-    public function getName()
+    public function getName(): string
     {
         return self::MULTIPOLYGON;
     }

--- a/src/Doctrine/Point.php
+++ b/src/Doctrine/Point.php
@@ -9,12 +9,12 @@ class Point extends Type
 {
     const POINT = 'point';
 
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
         return 'point';
     }
 
-    public function getName()
+    public function getName(): string
     {
         return self::POINT;
     }

--- a/src/Doctrine/Polygon.php
+++ b/src/Doctrine/Polygon.php
@@ -9,12 +9,12 @@ class Polygon extends Type
 {
     const POLYGON = 'polygon';
 
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
         return 'polygon';
     }
 
-    public function getName()
+    public function getName(): string
     {
         return self::POLYGON;
     }

--- a/src/MysqlConnection.php
+++ b/src/MysqlConnection.php
@@ -26,11 +26,40 @@ class MysqlConnection extends IlluminateMySqlConnection
                 'geometrycollection',
                 'geomcollection',
             ];
-            $dbPlatform = $this->getDoctrineSchemaManager()->getDatabasePlatform();
+            $dbPlatform = $this->getDoctrineConnection()->getDatabasePlatform();
             foreach ($geometries as $type) {
                 $dbPlatform->registerDoctrineTypeMapping($type, 'string');
             }
         }
+    }
+
+    protected function getDoctrineConnection(): DoctrineConnection
+    {
+        return $this->getDoctrineDriver()->connect($this->getDoctrineConfig());
+    }
+
+    protected function getDoctrineDriver(): \Doctrine\DBAL\Driver
+    {
+        $driverClass = $this->getDoctrineDriverClass();
+        return new $driverClass;
+    }
+
+    protected function getDoctrineDriverClass(): string
+    {
+        return \Doctrine\DBAL\Driver\PDOMySql\Driver::class;
+    }
+
+    protected function getDoctrineConfig(): array
+    {
+        return [
+            'pdo' => $this->getPdo(),
+            'dbname' => $this->getDatabaseName(),
+            'user' => $this->getConfig('username'),
+            'password' => $this->getConfig('password'),
+            'host' => $this->getConfig('host'),
+            'port' => $this->getConfig('port'),
+            'driver' => 'pdo_mysql',
+        ];
     }
 
     /**

--- a/src/MysqlConnection.php
+++ b/src/MysqlConnection.php
@@ -3,14 +3,11 @@
 namespace Grimzy\LaravelMysqlSpatial;
 
 use Doctrine\DBAL\Types\Type as DoctrineType;
-use Grimzy\LaravelMysqlSpatial\Schema\Builder;
-use Grimzy\LaravelMysqlSpatial\Schema\Grammars\MySqlGrammar;
-use Illuminate\Database\MySqlConnection as IlluminateMySqlConnection;
-use Doctrine\DBAL\Types\Type as DoctrineType;
-use Grimzy\LaravelMysqlSpatial\Schema\Builder;
-use Grimzy\LaravelMysqlSpatial\Schema\Grammars\MySqlGrammar;
-use Illuminate\Database\MySqlConnection as IlluminateMySqlConnection;
 use Doctrine\DBAL\Connection as DoctrineConnection;
+use Grimzy\LaravelMysqlSpatial\Schema\Builder;
+use Grimzy\LaravelMysqlSpatial\Schema\Grammars\MySqlGrammar;
+use Illuminate\Database\MySqlConnection as IlluminateMySqlConnection;
+
 
 class MysqlConnection extends IlluminateMySqlConnection
 {

--- a/src/MysqlConnection.php
+++ b/src/MysqlConnection.php
@@ -6,6 +6,11 @@ use Doctrine\DBAL\Types\Type as DoctrineType;
 use Grimzy\LaravelMysqlSpatial\Schema\Builder;
 use Grimzy\LaravelMysqlSpatial\Schema\Grammars\MySqlGrammar;
 use Illuminate\Database\MySqlConnection as IlluminateMySqlConnection;
+use Doctrine\DBAL\Types\Type as DoctrineType;
+use Grimzy\LaravelMysqlSpatial\Schema\Builder;
+use Grimzy\LaravelMysqlSpatial\Schema\Grammars\MySqlGrammar;
+use Illuminate\Database\MySqlConnection as IlluminateMySqlConnection;
+use Doctrine\DBAL\Connection as DoctrineConnection;
 
 class MysqlConnection extends IlluminateMySqlConnection
 {


### PR DESCRIPTION
```
In Geometry.php line 12:

  Declaration of Grimzy\LaravelMysqlSpatial\Doctrine\Geometry::getSQLDeclaration(array $fieldDeclaration, Doctrine\DBAL\Platforms\AbstractPlatform $platform) must be compatible with Doctrine\DBAL\Types\Type::get
  SQLDeclaration(array $column, Doctrine\DBAL\Platforms\AbstractPlatform $platform): string


Script @php artisan package:discover --ansi handling the post-autoload-dump event returned with error code 255

```